### PR TITLE
Add matching service

### DIFF
--- a/matching-service/.dockerignore
+++ b/matching-service/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.gitignore
+src/node_modules/

--- a/matching-service/.gitignore
+++ b/matching-service/.gitignore
@@ -1,0 +1,3 @@
+**/node_modules
+package-lock.json
+.git

--- a/matching-service/.gitignore
+++ b/matching-service/.gitignore
@@ -1,3 +1,2 @@
 **/node_modules
 package-lock.json
-.git

--- a/matching-service/Dockerfile
+++ b/matching-service/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:alpine
+WORKDIR /usr/src/app
+COPY package*.json .
+RUN npm i
+COPY . .
+CMD ["npm", "start"]

--- a/matching-service/README.md
+++ b/matching-service/README.md
@@ -1,0 +1,15 @@
+# Matching Service Documentation
+
+The matching service will start matching 2 users based on their chosen level of difficulty and proficiency level.
+
+## TOC
+1. [Setting up service](#Setting-up-service)
+2. [Usage](#Usage)
+
+## Setting up service
+1. cd matching-service
+2. Run `npm i` to install relevant dependencies
+3. Run `npm start` to start the matching service server
+
+## Usage
+Open 'localhost:3000' to view the index.html and test out the matchmaking service

--- a/matching-service/README.md
+++ b/matching-service/README.md
@@ -12,4 +12,4 @@ The matching service will start matching 2 users based on their chosen level of 
 3. Run `npm start` to start the matching service server
 
 ## Usage
-Open 'localhost:3000' to view the index.html and test out the matchmaking service
+Open 'localhost:8001' to view the index.html and test out the matchmaking service

--- a/matching-service/docker-compose.yml
+++ b/matching-service/docker-compose.yml
@@ -5,4 +5,4 @@ services:
     image: matching-service:latest
     build: .
     ports: 
-      - 3000:3000
+      - 8001:8001

--- a/matching-service/docker-compose.yml
+++ b/matching-service/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.9'
+
+services:
+  matching-service:
+    image: matching-service:latest
+    build: .
+    ports: 
+      - 3000:3000

--- a/matching-service/index.html
+++ b/matching-service/index.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Matching Service</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            text-align: center;
+        }
+        h1 {
+            margin-top: 20px;
+        }
+        .input-container {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            margin-top: 20px;
+        }
+        label {
+            margin-right: 10px;
+        }
+        select {
+            padding: 5px;
+        }
+        button {
+            padding: 10px 20px;
+            margin-top: 10px;
+            background-color: #007BFF;
+            color: white;
+            border: none;
+            cursor: pointer;
+        }
+    </style>
+</head>
+<body>
+    <h1>Welcome to the Matching Service</h1>
+    <div class="input-container">
+        <label for="difficulty">Select Difficulty:</label>
+        <select id="difficulty">
+            <option value="easy">Easy</option>
+            <option value="medium">Medium</option>
+            <option value="hard">Hard</option>
+        </select>
+    </div>
+    <div class="input-container">
+        <label for="proficiency">Select Proficiency:</label>
+        <select id="proficiency">
+            <option value="beginner">Beginner</option>
+            <option value="intermediate">Intermediate</option>
+            <option value="advanced">Advanced</option>
+        </select>
+    </div>
+    <button id="matchButton">Find Match</button>
+    <button id="cancelButton" style="display:none; margin-left: 10px;">Cancel Match</button>
+    
+    <div id="matchStatus"></div>
+
+    <script src="/socket.io/socket.io.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const matchButton = document.getElementById('matchButton');
+            const cancelButton = document.getElementById('cancelButton');
+            const matchStatus = document.getElementById('matchStatus');
+            const socket = io();
+
+            let isMatching = false;
+
+            matchButton.addEventListener('click', () => {
+                const difficulty = document.getElementById('difficulty').value;
+                const proficiency = document.getElementById('proficiency').value;
+                
+                // Send the Matching criteria to the server using the 'register' event
+                socket.emit('start-matching', { difficulty, proficiency });
+                
+                // Display a message indicating that Matching is in progress
+                matchStatus.innerHTML = 'Searching for a match...';
+                isMatching = true;
+
+                 // Hide the "Find Match" button and show the "Cancel Match" button
+                matchButton.style.display = 'none';
+                cancelButton.style.display = 'block';
+            });
+
+            cancelButton.addEventListener('click', () => {
+                if (isMatching) {
+                    socket.emit('cancel-matching');
+                    matchStatus.innerHTML = 'Matching cancelled.';
+                    isMatching = false;
+
+                    // Hide the "Cancel Match" button and show the "Find Match" button
+                    matchButton.style.display = 'block';
+                    cancelButton.style.display = 'none';
+                }
+            });
+            socket.on('match-found', (data) => {
+            matchStatus.innerHTML = `Match found with user ${data.userId}`;
+            isMatching = false;
+
+            // Hide the "Cancel Match" button and show the "Find Match" button
+            matchButton.style.display = 'block';
+            cancelButton.style.display = 'none';
+            });
+
+            socket.on('match-timeout', () => {
+                matchStatus.innerHTML = 'Matching timed out. Please try again later.';
+                isMatching = false;
+
+                // Hide the "Cancel Match" button and show the "Find Match" button
+                matchButton.style.display = 'block';
+                cancelButton.style.display = 'none';
+            });
+
+        });
+    </script>
+</body>
+</html>

--- a/matching-service/package.json
+++ b/matching-service/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "matching-service",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "amqplib": "^0.10.3",
+    "express": "^4.18.2",
+    "socket.io": "^4.7.2"
+  }
+}

--- a/matching-service/package.json
+++ b/matching-service/package.json
@@ -11,7 +11,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "amqplib": "^0.10.3",
     "express": "^4.18.2",
     "socket.io": "^4.7.2"
   }

--- a/matching-service/server.js
+++ b/matching-service/server.js
@@ -3,7 +3,7 @@ const app = express();
 const http = require("http").createServer(app);
 const io = require("socket.io")(http);
 
-const PORT = 3000;
+const PORT = 8001;
 const MATCHMAKING_TIMEOUT = 30000; // 30 seconds
 
 const connectedUsers = [];

--- a/matching-service/server.js
+++ b/matching-service/server.js
@@ -1,0 +1,151 @@
+const express = require("express");
+const app = express();
+const http = require("http").createServer(app);
+const io = require("socket.io")(http);
+// const amqp = require("amqplib/callback_api");
+
+const PORT = 3000;
+// const AMQP_URL = "amqp://localhost";
+const MATCHMAKING_TIMEOUT = 30000; // 30 seconds
+
+const connectedUsers = [];
+const matchingQueue = [];
+
+function isUserInQueue(userId) {
+  return matchingQueue.some((entry) => entry.userId === userId);
+}
+
+function handleMatchingCancellation(userId) {
+  if (isUserInQueue(userId)) {
+    removeUserFromQueue(userId);
+    io.to(userId).emit("match-cancelled");
+    console.log(`User ${userId} cancelled matchmaking.`);
+  }
+}
+
+io.on("connection", (socket) => {
+  console.log(`User ${socket.id} is connected`);
+
+  // user data refers to chosen level of difficult and proficiency
+  socket.on("start-matching", (userData) => {
+    connectedUsers.push({ id: socket.id, ...userData });
+    console.log(`User ${socket.id} trying to match with data:`, userData);
+    tryMatchingUser(socket.id, userData);
+  });
+
+  socket.on("cancel-matching", () => {
+    handleMatchingCancellation(socket.id);
+  });
+
+  socket.on("disconnect", () => {
+    console.log(`User ${socket.id} has disconnected`);
+    const index = connectedUsers.findIndex((user) => user.id === socket.id);
+    if (index !== -1) {
+      connectedUsers.splice(index, 1);
+    }
+    removeUserFromQueue(socket.id);
+  });
+});
+
+function tryMatchingUser(userId, userCriteria) {
+  const matchingUser = matchingQueue.findIndex((user) =>
+    isMatch(user.criteria, userCriteria)
+  );
+
+  if (matchingUser !== -1) {
+    const user2 = matchingQueue.splice(matchingUser, 1)[0];
+    createMatch(userId, user2.userId);
+  } else {
+    matchingQueue.push({ userId, criteria: userCriteria });
+  }
+
+  // Timeout for matchmaking of current user
+  setTimeout(() => {
+    handleMatchmakingTimeout(userId);
+  }, MATCHMAKING_TIMEOUT);
+}
+
+function isMatch(criteria1, criteria2) {
+  return (
+    criteria1.difficulty === criteria2.difficulty &&
+    criteria1.proficiency === criteria2.proficiency
+  );
+}
+
+function createMatch(userId1, userId2) {
+  io.to(userId1).emit("match-found", { userId: userId2 });
+  io.to(userId2).emit("match-found", { userId: userId1 });
+  removeUserFromQueue(userId1);
+  removeUserFromQueue(userId2);
+  console.log(`Match found: ${userId1} and ${userId2}`);
+}
+
+function removeUserFromQueue(userId) {
+  const index = matchingQueue.findIndex((entry) => entry.userId === userId);
+  if (index !== -1) {
+    matchingQueue.splice(index, 1);
+  }
+}
+
+function handleMatchmakingTimeout(userId) {
+  // Remove the user from the matching queue
+  removeUserFromQueue(userId);
+
+  // Notify the user that matchmaking timed out
+  io.to(userId).emit("match-timeout");
+
+  console.log(`User ${userId} has timed out from matching.`);
+}
+
+app.get("/", (req, res) => {
+  res.sendFile(__dirname + "/index.html");
+});
+
+http.listen(PORT, () => {
+  console.log(`Matching Service Server is running on http://localhost:${PORT}`);
+});
+
+// RabbitMQ setup
+// function startServer() {
+//     amqp.connect(AMQP_URL, (error0, connection) => {
+//     if (error0) {
+//         throw error0;
+//     }
+
+//     connection.createChannel((error1, channel) => {
+//         if (error1) {
+//         throw error1;
+//         }
+
+//         const exchange = "matchmaking-exchange";
+//         const queueName = "matchmaking-queue";
+
+//         channel.assertExchange(exchange, "direct", { durable: false });
+//         channel.assertQueue(queueName, { exclusive: false });
+
+//         channel.bindQueue(queueName, exchange, "");
+
+//         channel.consume(
+//         queueName,
+//         (msg) => {
+//             const message = JSON.parse(msg.content.toString());
+
+//             // Check if the message is a match cancellation request
+//             if (message.type === "cancel-match") {
+//             // Forward the cancellation request to the user's specific queue
+//             const userQueueName = `/user/${message.userId}/queue/matchmaking`;
+//             channel.sendToQueue(
+//                 userQueueName,
+//                 Buffer.from(JSON.stringify(message))
+//             );
+//             console.log(`Sent cancel-match message to user ${message.userId}`);
+//             }
+//         },
+//         {
+//             noAck: true,
+//         }
+//         );
+//     });
+//     });
+// }
+// startServer();


### PR DESCRIPTION
The current implementation uses socket.io to establish connections between new tabs (each tab registers as 1 user) on localhost:3000. Upon selecting difficulty and proficiency level, the users will start matching, and times out after 30 seconds. FIFO queuing logic is applied here. A simple index.html is included to demonstrate the matching process. No match found simply removes the user from queue. 

closes #16 

Issues faced:
Unable to set up Rabbitmq locally on com or using Docker image but have yet to try to host it on cloud. Updated: use socket.io only and not rabbitmq

Requirements for assignment 5:
- [x] Demonstrating the two users’ inputs to specify the criteria for matching
- [x] Front-end timer + feedback + handling no match
- [x] Demonstrating the valid matching
- [x] Containerise

![image](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g34/assets/45199780/8b8776ac-5bd5-45cc-a7cd-c2ca2b36feba)
![image](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g34/assets/45199780/cfc8ca8f-0227-4d63-add2-551071cb311b)
![image](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g34/assets/45199780/8ab79df0-8437-414d-85ac-be00c5ee476f)
